### PR TITLE
[fix] 表示のメニューを正常に選択できない不具合を修正した

### DIFF
--- a/cafe.rb
+++ b/cafe.rb
@@ -19,7 +19,7 @@ def take_order(menus)
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
   end
   print '>'
-  order_number = gets.to_i
+  order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
   order_number
 end
@@ -30,5 +30,5 @@ order1 = take_order(DRINKS)
 puts 'フードメニューはいかがですか?'
 order2 = take_order(FOODS)
 
-total = FOODS[order1][:price] + DRINKS[order2][:price]
+total = DRINKS[order1][:price].to_i + FOODS[order2][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -25,10 +25,10 @@ def take_order(menus)
 end
 
 puts 'bugカフェへようこそ！ご注文は？ 番号でどうぞ'
-order1 = take_order(DRINKS)
+drink_order_number = take_order(DRINKS)
 
 puts 'フードメニューはいかがですか?'
-order2 = take_order(FOODS)
+food_order_number = take_order(FOODS)
 
-total = DRINKS[order1][:price].to_i + FOODS[order2][:price].to_i
+total = DRINKS[drink_order_number][:price].to_i + FOODS[food_order_number][:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"

--- a/cafe.rb
+++ b/cafe.rb
@@ -14,6 +14,7 @@ FOODS = [
   { name: 'ホットサンド', price: '410' }
 ].freeze
 
+# メニュー配列を受け取り、選択されたメニュー番号に一致するメニューを返す
 def take_order(menus)
   menus.each.with_index(1) do |menu, i|
     puts "(#{i})#{menu[:name]}: #{menu[:price]}円"
@@ -21,14 +22,14 @@ def take_order(menus)
   print '>'
   order_number = gets.to_i - 1
   puts "#{menus[order_number][:name]}(#{menus[order_number][:price]}円)ですね。"
-  order_number
+  menus[order_number]
 end
 
 puts 'bugカフェへようこそ！ご注文は？ 番号でどうぞ'
-drink_order_number = take_order(DRINKS)
+drink = take_order(DRINKS)
 
 puts 'フードメニューはいかがですか?'
-food_order_number = take_order(FOODS)
+food = take_order(FOODS)
 
-total = DRINKS[drink_order_number][:price].to_i + FOODS[food_order_number][:price].to_i
+total = drink[:price].to_i + food[:price].to_i
 puts "お会計は#{total}円になります。ありがとうございました！"


### PR DESCRIPTION
## 背景
cafe.rb実行時、メニューを指定しても期待したメニューを注文できない

![CleanShot 2024-10-03 at 16 56 37@2x](https://github.com/user-attachments/assets/5a77b56c-c843-4621-b8c2-636d6d83c55a)

## やったこと
- [x] 表示のメニューを正常に選択できない不具合を修正した
  - [x] 指定番号のメニューが選択できない不具合を修正した
  - [x] 合計金額計算を修正した
    - [x] 別メニューの金額を合計していたのを修正した
    - [x] 文字列を連結していたのを数値で合計するよう修正した

## 確認方法
`ruby cafe.rb` で、指定のメニューが選択でき、合計金額が正しいこと

![CleanShot 2024-10-03 at 16 56 37@2x](https://github.com/user-attachments/assets/5b8a28e1-d630-4e44-97cb-c9cf19a20e8f)
